### PR TITLE
Improve Drag Accuracy, Snap Guide Precision, and Element Coordinate Handling

### DIFF
--- a/src/components/BottomDrawer/index.tsx
+++ b/src/components/BottomDrawer/index.tsx
@@ -1,5 +1,5 @@
 import { Animations } from '@/constants';
-import { screenHeight } from '@/utils';
+import { windowHeight } from '@/utils';
 import { ReactNode, useEffect, useState } from 'react';
 import { View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
@@ -19,7 +19,7 @@ interface BottomDrawerProps {
   height?: number;
 }
 
-const DEFAULT_DRAWER_HEIGHT = screenHeight * 0.85;
+const DEFAULT_DRAWER_HEIGHT = windowHeight * 0.85;
 
 const BottomDrawer: React.FC<BottomDrawerProps> = ({
   visible,

--- a/src/components/SnapGuides/index.tsx
+++ b/src/components/SnapGuides/index.tsx
@@ -1,4 +1,5 @@
-import { Colors, Opacity, Spacing, zIndex } from '@/constants/theme';
+import { CANVAS_SNAP_WIDTH } from '@/constants/templates';
+import { Colors, Opacity, zIndex } from '@/constants/theme';
 import { FC } from 'react';
 import Animated, { type SharedValue, useAnimatedStyle } from 'react-native-reanimated';
 
@@ -24,10 +25,10 @@ const SnapGuides: FC<SnapGuidesProps> = ({
     position: 'absolute',
     left: snapLineX.value - 0.5,
     top: 0,
-    width: Spacing.tiny,
+    width: CANVAS_SNAP_WIDTH,
     height: canvasHeight,
     backgroundColor: Colors.snapColor,
-    zIndex: zIndex.modal,
+    zIndex: zIndex.background,
   }));
 
   const snapGuideYStyle = useAnimatedStyle(() => ({
@@ -36,9 +37,9 @@ const SnapGuides: FC<SnapGuidesProps> = ({
     left: 0,
     top: snapLineY.value - 0.5,
     width: canvasWidth,
-    height: Spacing.tiny,
+    height: CANVAS_SNAP_WIDTH,
     backgroundColor: Colors.snapColor,
-    zIndex: zIndex.modal,
+    zIndex: zIndex.background,
   }));
 
   return (

--- a/src/components/SnapGuides/index.tsx
+++ b/src/components/SnapGuides/index.tsx
@@ -1,5 +1,5 @@
 import { CANVAS_SNAP_WIDTH } from '@/constants/templates';
-import { Colors, Opacity, zIndex } from '@/constants/theme';
+import { Colors, Opacity } from '@/constants/theme';
 import { FC } from 'react';
 import Animated, { type SharedValue, useAnimatedStyle } from 'react-native-reanimated';
 
@@ -28,7 +28,6 @@ const SnapGuides: FC<SnapGuidesProps> = ({
     width: CANVAS_SNAP_WIDTH,
     height: canvasHeight,
     backgroundColor: Colors.snapColor,
-    zIndex: zIndex.background,
   }));
 
   const snapGuideYStyle = useAnimatedStyle(() => ({
@@ -39,7 +38,6 @@ const SnapGuides: FC<SnapGuidesProps> = ({
     width: canvasWidth,
     height: CANVAS_SNAP_WIDTH,
     backgroundColor: Colors.snapColor,
-    zIndex: zIndex.background,
   }));
 
   return (

--- a/src/constants/templates.ts
+++ b/src/constants/templates.ts
@@ -1,6 +1,7 @@
-import { ImageSourcePropType } from 'react-native';
-
 import { CanvasElementItem, ImageInterface } from '@/types/editor';
+import { ImageSourcePropType } from 'react-native';
+import { Spacing } from './theme';
+
 import meme1 from '../assets/images/meme1.jpg';
 import meme2 from '../assets/images/meme2.jpg';
 import meme3 from '../assets/images/meme3.jpg';
@@ -20,6 +21,9 @@ import webDevelopment from '../assets/stickers/web-development.png';
 // developer emulator device size, for comparison purposes
 export const PROPORTIONAL_WIDTH = 411.428571;
 export const PROPORTIONAL_HEIGHT = 914.285714;
+
+export const CANVAS_SNAP_WIDTH = Spacing.tiny;
+export const CANVAS_SNAP_SCALE_FACTOR = CANVAS_SNAP_WIDTH * 2;
 
 export interface MemeTemplate {
   id: string;

--- a/src/constants/templates.ts
+++ b/src/constants/templates.ts
@@ -29,7 +29,7 @@ export interface MemeTemplate {
 
 const ELEMENTS_DEMO_MEME1: CanvasElementItem[] = [
   {
-    id: 'el-demo-meme-1',
+    id: 'el-demo-meme-1-1',
     type: 'text',
     text: 'Thoriq Dharmawan',
     x: 190.00928622484207,
@@ -41,7 +41,7 @@ const ELEMENTS_DEMO_MEME1: CanvasElementItem[] = [
     fontSize: 24,
   },
   {
-    id: 'el-demo-meme-2',
+    id: 'el-demo-meme-2-1',
     type: 'text',
     text: 'Kandidat Lain',
     x: 189.24924212694168,
@@ -100,7 +100,7 @@ const ELEMENTS_DEMO_MEME2: CanvasElementItem[] = [
 
 const ELEMENTS_DEMO_MEME3: CanvasElementItem[] = [
   {
-    id: 'el-demo-meme-1',
+    id: 'el-demo-meme-1-3',
     type: 'text',
     text: 'Thoriq Dharmawan',
     x: 45.31287384033203,
@@ -113,7 +113,7 @@ const ELEMENTS_DEMO_MEME3: CanvasElementItem[] = [
     backgroundColor: '#FFFFFF',
   },
   {
-    id: 'el-demo-meme-2',
+    id: 'el-demo-meme-2-3',
     type: 'text',
     text: 'Kandidat Lain',
     x: 248.14694690704346,
@@ -126,7 +126,7 @@ const ELEMENTS_DEMO_MEME3: CanvasElementItem[] = [
     backgroundColor: '#FFFFFF',
   },
   {
-    id: 'el-demo-meme-3',
+    id: 'el-demo-meme-3-3',
     type: 'text',
     text: 'Lahelu',
     x: 176.73475110530853,
@@ -142,7 +142,7 @@ const ELEMENTS_DEMO_MEME3: CanvasElementItem[] = [
 
 const ELEMENTS_DEMO_MEME4: CanvasElementItem[] = [
   {
-    id: 'el-demo-meme-2',
+    id: 'el-demo-meme-2-4',
     type: 'text',
     text: 'Mahasiswa Semester Akhir',
     x: 61.880950927734375,
@@ -155,7 +155,7 @@ const ELEMENTS_DEMO_MEME4: CanvasElementItem[] = [
     backgroundColor: 'transparent',
   },
   {
-    id: 'el-demo-meme-1',
+    id: 'el-demo-meme-1-4',
     type: 'text',
     text: 'Belajar buat ujian',
     x: 20.22023904323578,
@@ -168,7 +168,7 @@ const ELEMENTS_DEMO_MEME4: CanvasElementItem[] = [
     backgroundColor: 'transparent',
   },
   {
-    id: '1748677200781-copy',
+    id: '1748677200781-copy-4',
     type: 'text',
     text: 'Nonton teori konspirasi 3 jam di YT',
     x: 182.89099872112274,

--- a/src/contexts/MemeEditorContext.tsx
+++ b/src/contexts/MemeEditorContext.tsx
@@ -9,6 +9,7 @@ interface MemeEditorContextType {
   setCanvases: React.Dispatch<React.SetStateAction<CanvasElement[]>>;
   selectedCanvas: CanvasElement | null;
   setSelectedCanvas: (canvas: CanvasElement | null) => void;
+  updateCanvas: (id: string, updates: Partial<CanvasElement>) => void;
 
   elements: CanvasElementItem[];
   setElements: React.Dispatch<React.SetStateAction<CanvasElementItem[]>>;
@@ -170,6 +171,21 @@ export const MemeEditorProvider: React.FC<MemeEditorProviderProps> = ({ children
     setSelectedCanvas(canvas);
   };
 
+  const updateCanvas = (id: string, updates: Partial<CanvasElement>) => {
+    const newCanvases = canvases.map(canvas => {
+      if (canvas.id === id) {
+        const updatedCanvas = { ...canvas, ...updates };
+        if (selectedCanvas?.id === id) {
+          setSelectedCanvas(updatedCanvas);
+        }
+        return updatedCanvas;
+      }
+      return canvas;
+    });
+
+    setCanvases(newCanvases);
+  };
+
   const onResetAll = () => {
     setCanvases([]);
     setSelectedCanvas(null);
@@ -193,6 +209,7 @@ export const MemeEditorProvider: React.FC<MemeEditorProviderProps> = ({ children
     setCanvases,
     selectedCanvas,
     setSelectedCanvas: handleSelectCanvas,
+    updateCanvas,
 
     elements,
     setElements,

--- a/src/features/MemeEditor/ActionInitial/DrawerText.tsx
+++ b/src/features/MemeEditor/ActionInitial/DrawerText.tsx
@@ -3,7 +3,7 @@ import Button from '@/components/Button';
 import { Colors, Spacing, Typography } from '@/constants';
 import { useMemeEditor } from '@/contexts/MemeEditorContext';
 import type { TextElement } from '@/types/editor';
-import { screenWidth } from '@/utils';
+import { windowWidth } from '@/utils';
 import { FC } from 'react';
 import { View } from 'react-native';
 import { styleDrawer } from './style';
@@ -24,7 +24,7 @@ interface TextVariant {
 }
 
 const DEFAULT_SPACING = Spacing.sectionSpacing;
-const DEFAULT_WIDTH = screenWidth - DEFAULT_SPACING * 4;
+const DEFAULT_WIDTH = windowWidth - DEFAULT_SPACING * 4;
 
 const DrawerText: FC<DrawerTextProps> = ({ visible, onClose }) => {
   const { addElement } = useMemeEditor();

--- a/src/features/MemeEditor/CanvasContainer/DrawerUseTemplate.tsx
+++ b/src/features/MemeEditor/CanvasContainer/DrawerUseTemplate.tsx
@@ -3,7 +3,7 @@ import { MEME_TEMPLATES, type MemeTemplate } from '@/constants';
 import { PROPORTIONAL_HEIGHT, PROPORTIONAL_WIDTH } from '@/constants/templates';
 import { useMemeEditor } from '@/contexts/MemeEditorContext';
 import type { CanvasElement } from '@/types/editor';
-import { calculateCanvasDimensions, getComparison, screenHeight, screenWidth } from '@/utils';
+import { calculateCanvasDimensions, getComparison, windowHeight, windowWidth } from '@/utils';
 import { FC, useState } from 'react';
 import { FlatList, Image, TouchableWithoutFeedback, View } from 'react-native';
 import { templateStyles } from './style';
@@ -40,11 +40,11 @@ const DrawerUseTemplate: FC<DrawerUseTemplateProps> = ({ onClose, visible }) => 
 
               return {
                 ...element,
-                x: getComparison(element.x, PROPORTIONAL_WIDTH, screenWidth),
-                y: getComparison(element.y, PROPORTIONAL_HEIGHT, screenHeight),
-                fontSize: getComparison(element.fontSize || 0, PROPORTIONAL_WIDTH, screenWidth),
-                width: getComparison(element.width, PROPORTIONAL_WIDTH, screenWidth),
-                rotate: getComparison(element.rotate || 0, PROPORTIONAL_WIDTH, screenWidth),
+                x: getComparison(element.x, PROPORTIONAL_WIDTH, windowWidth),
+                y: getComparison(element.y, PROPORTIONAL_HEIGHT, windowHeight),
+                fontSize: getComparison(element.fontSize || 0, PROPORTIONAL_WIDTH, windowWidth),
+                width: getComparison(element.width, PROPORTIONAL_WIDTH, windowWidth),
+                rotate: getComparison(element.rotate || 0, PROPORTIONAL_WIDTH, windowWidth),
               };
             }) || []
           );

--- a/src/features/MemeEditor/CanvasContainer/index.tsx
+++ b/src/features/MemeEditor/CanvasContainer/index.tsx
@@ -2,7 +2,7 @@ import Button from '@/components/Button';
 import Icon from '@/components/icon';
 import { useMemeEditor } from '@/contexts/MemeEditorContext';
 import { useCanvasPan } from '@/hooks';
-import { clamp, screenHeight, screenWidth } from '@/utils';
+import { clamp, windowHeight, windowWidth } from '@/utils';
 import { FC, useState } from 'react';
 import { ImageBackground, Text, TouchableWithoutFeedback, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
@@ -31,8 +31,8 @@ const CanvasContainer: FC<CanvasContainerProps> = ({ children }) => {
   const [drawer, setDrawer] = useState<DrawerState>(DEFAULT_DRAWER_STATE);
 
   const { pan, translationX, translationY } = useCanvasPan({
-    screenWidth,
-    screenHeight,
+    windowWidth,
+    windowHeight,
   });
 
   const scale = useSharedValue(1);
@@ -46,7 +46,7 @@ const CanvasContainer: FC<CanvasContainerProps> = ({ children }) => {
       scale.value = clamp(
         startScale.value * event.scale,
         0.5,
-        Math.min(screenWidth / 100, screenHeight / 100)
+        Math.min(windowWidth / 100, windowHeight / 100)
       );
     })
     .runOnJS(true);

--- a/src/features/MemeEditor/CanvasContainer/index.tsx
+++ b/src/features/MemeEditor/CanvasContainer/index.tsx
@@ -30,10 +30,7 @@ const CanvasContainer: FC<CanvasContainerProps> = ({ children }) => {
 
   const [drawer, setDrawer] = useState<DrawerState>(DEFAULT_DRAWER_STATE);
 
-  const { pan, translationX, translationY } = useCanvasPan({
-    screenWidth,
-    screenHeight,
-  });
+  const { pan, translationX, translationY } = useCanvasPan();
 
   const scale = useSharedValue(1);
   const startScale = useSharedValue(1);

--- a/src/features/MemeEditor/CanvasContainer/index.tsx
+++ b/src/features/MemeEditor/CanvasContainer/index.tsx
@@ -26,15 +26,23 @@ const DEFAULT_DRAWER_STATE: DrawerState = {
 };
 
 const CanvasContainer: FC<CanvasContainerProps> = ({ children }) => {
-  const { hasCanvas, selectedCanvas, canvases, setSelectedCanvas } = useMemeEditor();
+  const { hasCanvas, selectedCanvas, canvases, setSelectedCanvas, updateCanvas } = useMemeEditor();
 
   const [drawer, setDrawer] = useState<DrawerState>(DEFAULT_DRAWER_STATE);
 
   const { pan, translationX, translationY } = useCanvasPan();
 
   const { pinch, scale } = usePinchGesture({
+    initialScale: (selectedCanvas || canvases[0])?.scale || 1,
     minScale: 0.5,
     maxScale: Math.min(screenWidth / 100, screenHeight / 100),
+    onEnd: finalScale => {
+      const canvas = selectedCanvas || canvases[0];
+
+      if (canvas) {
+        updateCanvas(canvas.id, { scale: finalScale });
+      }
+    },
   });
 
   const boxAnimatedStyles = useAnimatedStyle(() => ({

--- a/src/features/MemeEditor/CanvasContainer/index.tsx
+++ b/src/features/MemeEditor/CanvasContainer/index.tsx
@@ -3,7 +3,7 @@ import Icon from '@/components/icon';
 import { useMemeEditor } from '@/contexts/MemeEditorContext';
 import { useCanvasPan } from '@/hooks';
 import { clamp, screenHeight, screenWidth } from '@/utils';
-import { FC, useState } from 'react';
+import { FC, useCallback, useState } from 'react';
 import { ImageBackground, Text, TouchableWithoutFeedback, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, { useAnimatedStyle, useSharedValue } from 'react-native-reanimated';
@@ -38,12 +38,14 @@ const CanvasContainer: FC<CanvasContainerProps> = ({ children }) => {
   const scale = useSharedValue(1);
   const startScale = useSharedValue(1);
 
-  const pinch = Gesture.Pinch()
+  const optimizedClamp = useCallback(clamp, []);
+
+  const pinchGestureHandler = Gesture.Pinch()
     .onStart(() => {
       startScale.value = scale.value;
     })
     .onUpdate(event => {
-      scale.value = clamp(
+      scale.value = optimizedClamp(
         startScale.value * event.scale,
         0.5,
         Math.min(screenWidth / 100, screenHeight / 100)
@@ -59,7 +61,7 @@ const CanvasContainer: FC<CanvasContainerProps> = ({ children }) => {
     ],
   }));
 
-  const combinedGesture = Gesture.Simultaneous(pan, pinch);
+  const combinedGesture = Gesture.Simultaneous(pan, pinchGestureHandler);
 
   const canvasStyle = {
     width: selectedCanvas?.width || canvases[0]?.width,

--- a/src/features/MemeEditor/CanvasContainer/index.tsx
+++ b/src/features/MemeEditor/CanvasContainer/index.tsx
@@ -3,7 +3,7 @@ import Icon from '@/components/icon';
 import { useMemeEditor } from '@/contexts/MemeEditorContext';
 import { useCanvasPan, usePinchGesture } from '@/hooks';
 import { screenHeight, screenWidth } from '@/utils';
-import { FC, useState } from 'react';
+import { FC, useMemo, useState } from 'react';
 import { ImageBackground, Text, TouchableWithoutFeedback, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, { useAnimatedStyle } from 'react-native-reanimated';
@@ -56,12 +56,16 @@ const CanvasContainer: FC<CanvasContainerProps> = ({ children }) => {
 
   const combinedGesture = Gesture.Simultaneous(pan, pinch);
 
-  const canvasStyle = {
-    width: selectedCanvas?.width || canvases[0]?.width,
-    height: selectedCanvas?.height || canvases[0]?.height,
-  };
-
   const currentCanvas = selectedCanvas || canvases[0];
+
+  const canvasStyle = useMemo(
+    () => ({
+      width: currentCanvas?.width,
+      height: currentCanvas?.height,
+    }),
+    [currentCanvas?.width, currentCanvas?.height]
+  );
+
   const hasBackgroundImage = currentCanvas?.backgroundImage;
 
   const renderCanvasContent = () => {

--- a/src/features/MemeEditor/CanvasContainer/index.tsx
+++ b/src/features/MemeEditor/CanvasContainer/index.tsx
@@ -1,12 +1,12 @@
 import Button from '@/components/Button';
 import Icon from '@/components/icon';
 import { useMemeEditor } from '@/contexts/MemeEditorContext';
-import { useCanvasPan } from '@/hooks';
-import { clamp, screenHeight, screenWidth } from '@/utils';
-import { FC, useCallback, useState } from 'react';
+import { useCanvasPan, usePinchGesture } from '@/hooks';
+import { screenHeight, screenWidth } from '@/utils';
+import { FC, useState } from 'react';
 import { ImageBackground, Text, TouchableWithoutFeedback, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import Animated, { useAnimatedStyle, useSharedValue } from 'react-native-reanimated';
+import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 import DrawerAddCanvas from './DrawerAddCanvas';
 import DrawerUseTemplate from './DrawerUseTemplate';
 import { styles } from './style';
@@ -32,23 +32,10 @@ const CanvasContainer: FC<CanvasContainerProps> = ({ children }) => {
 
   const { pan, translationX, translationY } = useCanvasPan();
 
-  const scale = useSharedValue(1);
-  const startScale = useSharedValue(1);
-
-  const optimizedClamp = useCallback(clamp, []);
-
-  const pinchGestureHandler = Gesture.Pinch()
-    .onStart(() => {
-      startScale.value = scale.value;
-    })
-    .onUpdate(event => {
-      scale.value = optimizedClamp(
-        startScale.value * event.scale,
-        0.5,
-        Math.min(screenWidth / 100, screenHeight / 100)
-      );
-    })
-    .runOnJS(true);
+  const { pinch, scale } = usePinchGesture({
+    minScale: 0.5,
+    maxScale: Math.min(screenWidth / 100, screenHeight / 100),
+  });
 
   const boxAnimatedStyles = useAnimatedStyle(() => ({
     transform: [
@@ -58,7 +45,7 @@ const CanvasContainer: FC<CanvasContainerProps> = ({ children }) => {
     ],
   }));
 
-  const combinedGesture = Gesture.Simultaneous(pan, pinchGestureHandler);
+  const combinedGesture = Gesture.Simultaneous(pan, pinch);
 
   const canvasStyle = {
     width: selectedCanvas?.width || canvases[0]?.width,

--- a/src/features/MemeEditor/CanvasContainer/index.tsx
+++ b/src/features/MemeEditor/CanvasContainer/index.tsx
@@ -2,7 +2,7 @@ import Button from '@/components/Button';
 import Icon from '@/components/icon';
 import { useMemeEditor } from '@/contexts/MemeEditorContext';
 import { useCanvasPan } from '@/hooks';
-import { clamp, windowHeight, windowWidth } from '@/utils';
+import { clamp, screenHeight, screenWidth, windowHeight, windowWidth } from '@/utils';
 import { FC, useState } from 'react';
 import { ImageBackground, Text, TouchableWithoutFeedback, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
@@ -46,7 +46,7 @@ const CanvasContainer: FC<CanvasContainerProps> = ({ children }) => {
       scale.value = clamp(
         startScale.value * event.scale,
         0.5,
-        Math.min(windowWidth / 100, windowHeight / 100)
+        Math.min(screenWidth / 100, screenHeight / 100)
       );
     })
     .runOnJS(true);

--- a/src/features/MemeEditor/CanvasContainer/index.tsx
+++ b/src/features/MemeEditor/CanvasContainer/index.tsx
@@ -2,7 +2,7 @@ import Button from '@/components/Button';
 import Icon from '@/components/icon';
 import { useMemeEditor } from '@/contexts/MemeEditorContext';
 import { useCanvasPan } from '@/hooks';
-import { clamp, screenHeight, screenWidth, windowHeight, windowWidth } from '@/utils';
+import { clamp, screenHeight, screenWidth } from '@/utils';
 import { FC, useState } from 'react';
 import { ImageBackground, Text, TouchableWithoutFeedback, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
@@ -31,8 +31,8 @@ const CanvasContainer: FC<CanvasContainerProps> = ({ children }) => {
   const [drawer, setDrawer] = useState<DrawerState>(DEFAULT_DRAWER_STATE);
 
   const { pan, translationX, translationY } = useCanvasPan({
-    windowWidth,
-    windowHeight,
+    screenWidth,
+    screenHeight,
   });
 
   const scale = useSharedValue(1);

--- a/src/features/MemeEditor/CanvasContainer/index.tsx
+++ b/src/features/MemeEditor/CanvasContainer/index.tsx
@@ -33,6 +33,7 @@ const CanvasContainer: FC<CanvasContainerProps> = ({ children }) => {
   const { pan, translationX, translationY } = useCanvasPan();
 
   const { pinch, scale } = usePinchGesture({
+    selectedId: selectedCanvas?.id,
     initialScale: (selectedCanvas || canvases[0])?.scale || 1,
     minScale: 0.5,
     maxScale: Math.min(screenWidth / 100, screenHeight / 100),

--- a/src/features/MemeEditor/DraggableImage/index.tsx
+++ b/src/features/MemeEditor/DraggableImage/index.tsx
@@ -26,6 +26,7 @@ interface Props {
   onSelectImageElement: (element: ImageElement | null) => void;
   canvasWidth?: number;
   canvasHeight?: number;
+  canvasScale: number;
 }
 
 const DraggableImage: FC<Props> = props => {
@@ -37,6 +38,7 @@ const DraggableImage: FC<Props> = props => {
     onSelectImageElement,
     canvasWidth = 0,
     canvasHeight = 0,
+    canvasScale,
   } = props;
 
   const [layoutElement, setLayoutElement] = useState<LayoutRectangle | null>(null);
@@ -64,6 +66,7 @@ const DraggableImage: FC<Props> = props => {
     elementWidth: Number(elWidth),
     elementHeight: Number(elHeight),
     isElementSelected,
+    canvasScale,
     onSelectElement: onSelectImageElement,
     onUpdate,
     updateSnapGuides,

--- a/src/features/MemeEditor/DraggableImage/index.tsx
+++ b/src/features/MemeEditor/DraggableImage/index.tsx
@@ -80,21 +80,12 @@ const DraggableImage: FC<Props> = props => {
     initialHeight: Number(elHeight),
     minWidth: Layout.textBox.minWidth,
     minHeight: Layout.textBox.minHeight,
-    onUpdate: updates => {
-      onUpdate({
-        width: updates.width,
-        height: updates.height,
-      });
-    },
+    onUpdate: ({ height, width }) => onUpdate({ width, height }),
   });
 
   const { rotationGesture, angle, updateAngle } = useRotationElement({
     initialAngle: element.rotate || 0,
-    onUpdate: updates => {
-      onUpdate({
-        rotate: updates.rotate,
-      });
-    },
+    onUpdate: ({ rotate }) => onUpdate({ rotate }),
   });
 
   const { tapGesture, handleTap } = useTapElement({

--- a/src/features/MemeEditor/DraggableImage/index.tsx
+++ b/src/features/MemeEditor/DraggableImage/index.tsx
@@ -75,6 +75,7 @@ const DraggableImage: FC<Props> = props => {
   });
 
   const { resizeGesture, boxWidth, boxHeight } = useResizeElement({
+    elementId: element.id,
     initialWidth: elWidth,
     initialHeight: Number(elHeight),
     minWidth: Layout.textBox.minWidth,

--- a/src/features/MemeEditor/DraggableImage/index.tsx
+++ b/src/features/MemeEditor/DraggableImage/index.tsx
@@ -80,12 +80,12 @@ const DraggableImage: FC<Props> = props => {
     initialHeight: Number(elHeight),
     minWidth: Layout.textBox.minWidth,
     minHeight: Layout.textBox.minHeight,
-    onUpdate: ({ height, width }) => onUpdate({ width, height }),
+    onUpdate,
   });
 
   const { rotationGesture, angle, updateAngle } = useRotationElement({
     initialAngle: element.rotate || 0,
-    onUpdate: ({ rotate }) => onUpdate({ rotate }),
+    onUpdate,
   });
 
   const { tapGesture, handleTap } = useTapElement({

--- a/src/features/MemeEditor/DraggableText/index.tsx
+++ b/src/features/MemeEditor/DraggableText/index.tsx
@@ -38,6 +38,7 @@ interface Props {
   setIsEditing: (isEditing: boolean) => void;
   canvasWidth?: number;
   canvasHeight?: number;
+  canvasScale: number;
 }
 
 const DraggableText: FC<Props> = props => {
@@ -51,6 +52,7 @@ const DraggableText: FC<Props> = props => {
     setIsEditing,
     canvasWidth = 0,
     canvasHeight = 0,
+    canvasScale = 1,
   } = props;
 
   const [layoutElement, setLayoutElement] = useState<LayoutRectangle | null>(null);
@@ -78,6 +80,7 @@ const DraggableText: FC<Props> = props => {
     elementWidth: Number(elWidth),
     elementHeight: Number(elHeight),
     isElementSelected,
+    canvasScale,
     onSelectElement,
     onUpdate,
     updateSnapGuides,

--- a/src/features/MemeEditor/DraggableText/index.tsx
+++ b/src/features/MemeEditor/DraggableText/index.tsx
@@ -89,6 +89,7 @@ const DraggableText: FC<Props> = props => {
   });
 
   const { resizeGesture, boxWidth, boxHeight } = useResizeElement({
+    elementId: element.id,
     initialWidth: elWidth,
     initialHeight: elHeight,
     minWidth: Layout.textBox.minWidth,

--- a/src/features/MemeEditor/DraggableText/index.tsx
+++ b/src/features/MemeEditor/DraggableText/index.tsx
@@ -94,21 +94,12 @@ const DraggableText: FC<Props> = props => {
     initialHeight: elHeight,
     minWidth: Layout.textBox.minWidth,
     minHeight: Layout.textBox.minHeight,
-    onUpdate: updates => {
-      onUpdate({
-        width: updates.width,
-        height: updates.height,
-      });
-    },
+    onUpdate: ({ height, width }) => onUpdate({ width, height }),
   });
 
   const { rotationGesture, angle, updateAngle } = useRotationElement({
     initialAngle: element.rotate || 0,
-    onUpdate: updates => {
-      onUpdate({
-        rotate: updates.rotate,
-      });
-    },
+    onUpdate: ({ rotate }) => onUpdate({ rotate }),
   });
 
   const { tapGesture, handleTap } = useTapElement({

--- a/src/features/MemeEditor/DraggableText/index.tsx
+++ b/src/features/MemeEditor/DraggableText/index.tsx
@@ -94,12 +94,12 @@ const DraggableText: FC<Props> = props => {
     initialHeight: elHeight,
     minWidth: Layout.textBox.minWidth,
     minHeight: Layout.textBox.minHeight,
-    onUpdate: ({ height, width }) => onUpdate({ width, height }),
+    onUpdate,
   });
 
   const { rotationGesture, angle, updateAngle } = useRotationElement({
     initialAngle: element.rotate || 0,
-    onUpdate: ({ rotate }) => onUpdate({ rotate }),
+    onUpdate,
   });
 
   const { tapGesture, handleTap } = useTapElement({

--- a/src/features/MemeEditor/DraggableText/style.ts
+++ b/src/features/MemeEditor/DraggableText/style.ts
@@ -1,4 +1,5 @@
 import { BorderRadius, Colors, Layout, Spacing, Typography } from '@/constants';
+import { zIndex } from '@/constants/theme';
 import { StyleSheet } from 'react-native';
 
 export const styles = StyleSheet.create({
@@ -24,6 +25,7 @@ export const styles = StyleSheet.create({
     position: 'absolute',
     right: 0,
     top: -Layout.textBox.actionBarOffset,
+    zIndex: zIndex.modal,
   },
   box: {
     backgroundColor: Colors.transparent,

--- a/src/features/MemeEditor/index.tsx
+++ b/src/features/MemeEditor/index.tsx
@@ -1,3 +1,4 @@
+import { CANVAS_SNAP_SCALE_FACTOR } from '@/constants/templates';
 import { useMemeEditor } from '@/contexts/MemeEditorContext';
 import type { ImageElement, TextElement } from '@/types/editor';
 import { TouchableWithoutFeedback, View } from 'react-native';
@@ -45,8 +46,8 @@ const MemeEditor = () => {
                     onSelectElement={handleSelectElement}
                     isEditing={isEditing}
                     setIsEditing={setIsEditing}
-                    canvasWidth={canvasWidth}
-                    canvasHeight={canvasHeight}
+                    canvasWidth={canvasWidth - CANVAS_SNAP_SCALE_FACTOR}
+                    canvasHeight={canvasHeight - CANVAS_SNAP_SCALE_FACTOR}
                     canvasScale={canvas?.scale || 1}
                   />
                 );
@@ -60,8 +61,8 @@ const MemeEditor = () => {
                   onDuplicate={position => duplicateElement(el.id, position)}
                   selectedImageElement={selectedElement as ImageElement}
                   onSelectImageElement={handleSelectElement}
-                  canvasWidth={canvasWidth}
-                  canvasHeight={canvasHeight}
+                  canvasWidth={canvasWidth - CANVAS_SNAP_SCALE_FACTOR}
+                  canvasHeight={canvasHeight - CANVAS_SNAP_SCALE_FACTOR}
                   canvasScale={canvas?.scale || 1}
                 />
               );

--- a/src/features/MemeEditor/index.tsx
+++ b/src/features/MemeEditor/index.tsx
@@ -47,6 +47,7 @@ const MemeEditor = () => {
                     setIsEditing={setIsEditing}
                     canvasWidth={canvasWidth}
                     canvasHeight={canvasHeight}
+                    canvasScale={canvas?.scale || 1}
                   />
                 );
               }
@@ -61,6 +62,7 @@ const MemeEditor = () => {
                   onSelectImageElement={handleSelectElement}
                   canvasWidth={canvasWidth}
                   canvasHeight={canvasHeight}
+                  canvasScale={canvas?.scale || 1}
                 />
               );
             })}

--- a/src/features/MemeEditor/index.tsx
+++ b/src/features/MemeEditor/index.tsx
@@ -28,6 +28,9 @@ const MemeEditor = () => {
   const canvasWidth = canvas?.width || 0;
   const canvasHeight = canvas?.height || 0;
 
+  const adjustedCanvasWidth = canvasWidth - CANVAS_SNAP_SCALE_FACTOR;
+  const adjustedCanvasHeight = canvasHeight - CANVAS_SNAP_SCALE_FACTOR;
+
   return (
     <>
       <CanvasContainer>
@@ -46,8 +49,8 @@ const MemeEditor = () => {
                     onSelectElement={handleSelectElement}
                     isEditing={isEditing}
                     setIsEditing={setIsEditing}
-                    canvasWidth={canvasWidth - CANVAS_SNAP_SCALE_FACTOR}
-                    canvasHeight={canvasHeight - CANVAS_SNAP_SCALE_FACTOR}
+                    canvasWidth={adjustedCanvasWidth}
+                    canvasHeight={adjustedCanvasHeight}
                     canvasScale={canvas?.scale || 1}
                   />
                 );
@@ -61,8 +64,8 @@ const MemeEditor = () => {
                   onDuplicate={position => duplicateElement(el.id, position)}
                   selectedImageElement={selectedElement as ImageElement}
                   onSelectImageElement={handleSelectElement}
-                  canvasWidth={canvasWidth - CANVAS_SNAP_SCALE_FACTOR}
-                  canvasHeight={canvasHeight - CANVAS_SNAP_SCALE_FACTOR}
+                  canvasWidth={adjustedCanvasWidth}
+                  canvasHeight={adjustedCanvasHeight}
                   canvasScale={canvas?.scale || 1}
                 />
               );

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -14,6 +14,12 @@ export { useRotationElement, type RotationElementOptions } from './useRotationEl
 
 export { useTapElement, type TapElementOptions } from './useTapElement';
 
-export { useCanvasPan, type CanvasPanOptions } from './useCanvasPan';
+export { useCanvasPan } from './useCanvasPan';
+
+export {
+  usePinchGesture,
+  type PinchGestureOptions,
+  type UsePinchGestureReturn,
+} from './usePinchGesture';
 
 export { useHistory, type HistoryState, type UseHistoryReturn } from './useHistory';

--- a/src/hooks/useCanvasPan.ts
+++ b/src/hooks/useCanvasPan.ts
@@ -5,8 +5,8 @@ import { Gesture } from 'react-native-gesture-handler';
 import { useSharedValue } from 'react-native-reanimated';
 
 export interface CanvasPanOptions {
-  screenWidth: number;
-  screenHeight: number;
+  windowWidth: number;
+  windowHeight: number;
 }
 
 /**
@@ -22,8 +22,8 @@ export interface CanvasPanOptions {
  * @example
  * ```typescript
  * const { pan, translationX, translationY, resetPosition } = useCanvasPan({
- *   screenWidth: Dimensions.get('window').width,
- *   screenHeight: Dimensions.get('window').height,
+ *   windowWidth: Dimensions.get('window').width,
+ *   windowHeight: Dimensions.get('window').height,
  * });
  *
  * // Use with Animated.View
@@ -35,7 +35,7 @@ export interface CanvasPanOptions {
  * ```
  */
 export const useCanvasPan = (options: CanvasPanOptions) => {
-  const { screenWidth, screenHeight } = options;
+  const { windowWidth, windowHeight } = options;
 
   const { canvases } = useMemeEditor();
 
@@ -59,8 +59,8 @@ export const useCanvasPan = (options: CanvasPanOptions) => {
     })
     .onUpdate(event => {
       // Calculate maximum translation boundaries (50px margin from screen edges)
-      const maxTranslateX = screenWidth / 2 - 50;
-      const maxTranslateY = screenHeight / 2 - 50;
+      const maxTranslateX = windowWidth / 2 - 50;
+      const maxTranslateY = windowHeight / 2 - 50;
 
       translationX.value = clamp(
         prevTranslationX.value + event.translationX,

--- a/src/hooks/useCanvasPan.ts
+++ b/src/hooks/useCanvasPan.ts
@@ -1,30 +1,20 @@
 import { useMemeEditor } from '@/contexts/MemeEditorContext';
-import { clamp } from '@/utils';
 import { useEffect } from 'react';
 import { Gesture } from 'react-native-gesture-handler';
 import { useSharedValue } from 'react-native-reanimated';
 
-export interface CanvasPanOptions {
-  screenWidth: number;
-  screenHeight: number;
-}
-
 /**
- * Custom hook for handling canvas pan gestures with boundary constraints
+ * Custom hook for handling canvas pan gestures without boundaries
  *
  * This hook provides pan gesture functionality for a canvas element, allowing users
- * to drag and move content while respecting screen boundaries. The pan movement
- * is constrained to prevent content from moving too far off-screen.
+ * to drag and move content freely without any constraints. The pan movement
+ * can extend infinitely in any direction.
  *
- * @param options - Configuration options including screen dimensions
- * @returns Object containing pan gesture, translation values, and reset function
+ * @returns Object containing pan gesture and translation values
  *
  * @example
  * ```typescript
- * const { pan, translationX, translationY, resetPosition } = useCanvasPan({
- *   screenWidth: Dimensions.get('screen').width,
- *   screenHeight: Dimensions.get('screen').height,
- * });
+ * const { pan, translationX, translationY } = useCanvasPan();
  *
  * // Use with Animated.View
  * <Animated.View style={[{ transform: [{ translateX: translationX }, { translateY: translationY }] }]}>
@@ -34,9 +24,7 @@ export interface CanvasPanOptions {
  * </Animated.View>
  * ```
  */
-export const useCanvasPan = (options: CanvasPanOptions) => {
-  const { screenWidth, screenHeight } = options;
-
+export const useCanvasPan = () => {
   const { canvases } = useMemeEditor();
 
   const translationX = useSharedValue(0);
@@ -58,20 +46,8 @@ export const useCanvasPan = (options: CanvasPanOptions) => {
       prevTranslationY.value = translationY.value;
     })
     .onUpdate(event => {
-      // Calculate maximum translation boundaries (50px margin from screen edges)
-      const maxTranslateX = screenWidth / 2 - 50;
-      const maxTranslateY = screenHeight / 2 - 50;
-
-      translationX.value = clamp(
-        prevTranslationX.value + event.translationX,
-        -maxTranslateX,
-        maxTranslateX
-      );
-      translationY.value = clamp(
-        prevTranslationY.value + event.translationY,
-        -maxTranslateY,
-        maxTranslateY
-      );
+      translationX.value = prevTranslationX.value + event.translationX;
+      translationY.value = prevTranslationY.value + event.translationY;
     })
     .runOnJS(true);
 

--- a/src/hooks/useCanvasPan.ts
+++ b/src/hooks/useCanvasPan.ts
@@ -33,11 +33,9 @@ export const useCanvasPan = () => {
   const prevTranslationY = useSharedValue(0);
 
   useEffect(() => {
-    if (canvases.length === 0) {
-      translationX.value = 0;
-      translationY.value = 0;
-    }
-  }, [canvases]);
+    translationX.value = 0;
+    translationY.value = 0;
+  }, [canvases?.[0]?.id]);
 
   const pan = Gesture.Pan()
     .minDistance(1)

--- a/src/hooks/useCanvasPan.ts
+++ b/src/hooks/useCanvasPan.ts
@@ -5,8 +5,8 @@ import { Gesture } from 'react-native-gesture-handler';
 import { useSharedValue } from 'react-native-reanimated';
 
 export interface CanvasPanOptions {
-  windowWidth: number;
-  windowHeight: number;
+  screenWidth: number;
+  screenHeight: number;
 }
 
 /**
@@ -22,8 +22,8 @@ export interface CanvasPanOptions {
  * @example
  * ```typescript
  * const { pan, translationX, translationY, resetPosition } = useCanvasPan({
- *   windowWidth: Dimensions.get('window').width,
- *   windowHeight: Dimensions.get('window').height,
+ *   screenWidth: Dimensions.get('screen').width,
+ *   screenHeight: Dimensions.get('screen').height,
  * });
  *
  * // Use with Animated.View
@@ -35,7 +35,7 @@ export interface CanvasPanOptions {
  * ```
  */
 export const useCanvasPan = (options: CanvasPanOptions) => {
-  const { windowWidth, windowHeight } = options;
+  const { screenWidth, screenHeight } = options;
 
   const { canvases } = useMemeEditor();
 
@@ -59,8 +59,8 @@ export const useCanvasPan = (options: CanvasPanOptions) => {
     })
     .onUpdate(event => {
       // Calculate maximum translation boundaries (50px margin from screen edges)
-      const maxTranslateX = windowWidth / 2 - 50;
-      const maxTranslateY = windowHeight / 2 - 50;
+      const maxTranslateX = screenWidth / 2 - 50;
+      const maxTranslateY = screenHeight / 2 - 50;
 
       translationX.value = clamp(
         prevTranslationX.value + event.translationX,

--- a/src/hooks/useDragElement.ts
+++ b/src/hooks/useDragElement.ts
@@ -84,9 +84,6 @@ export const useDragElement = <T extends CanvasElementItem = CanvasElementItem>(
   const translateX = useSharedValue(initialX);
   const translateY = useSharedValue(initialY);
 
-  const canvasWidthScaled = canvasWidth;
-  const canvasHeightScaled = canvasHeight;
-
   const dragGesture = Gesture.Pan()
     .onStart(() => {
       startX.value = translateX.value;
@@ -101,16 +98,16 @@ export const useDragElement = <T extends CanvasElementItem = CanvasElementItem>(
       translateY.value = startY.value + e.translationY / canvasScale;
 
       updateSnapGuides(translateX.value, translateY.value, {
-        canvasWidth: canvasWidthScaled,
-        canvasHeight: canvasHeightScaled,
+        canvasWidth,
+        canvasHeight,
         elementWidth,
         elementHeight,
       });
     })
     .onEnd(() => {
       const snapResult = calculateSnapPosition(translateX.value, translateY.value, {
-        canvasWidth: canvasWidthScaled,
-        canvasHeight: canvasHeightScaled,
+        canvasWidth,
+        canvasHeight,
         elementWidth,
         elementHeight,
       });

--- a/src/hooks/useDragElement.ts
+++ b/src/hooks/useDragElement.ts
@@ -105,7 +105,7 @@ export const useDragElement = <T extends CanvasElementItem = CanvasElementItem>(
       });
     })
     .onEnd(() => {
-      const snapResult = calculateSnapPosition(translateX.value, translateY.value, {
+      const { finalX, finalY } = calculateSnapPosition(translateX.value, translateY.value, {
         canvasWidth,
         canvasHeight,
         elementWidth,
@@ -114,8 +114,8 @@ export const useDragElement = <T extends CanvasElementItem = CanvasElementItem>(
 
       hideSnapGuides();
 
-      const finalSnapX = snapResult.finalX - CANVAS_SNAP_SCALE_FACTOR;
-      const finalSnapY = snapResult.finalY - CANVAS_SNAP_SCALE_FACTOR;
+      const finalSnapX = finalX - (finalX === 0 ? 0 : CANVAS_SNAP_SCALE_FACTOR);
+      const finalSnapY = finalY - (finalY === 0 ? 0 : CANVAS_SNAP_SCALE_FACTOR);
 
       translateX.value = withSpring(finalSnapX, { damping: 20 });
       translateY.value = withSpring(finalSnapY, { damping: 20 });

--- a/src/hooks/useDragElement.ts
+++ b/src/hooks/useDragElement.ts
@@ -84,6 +84,10 @@ export const useDragElement = <T extends CanvasElementItem = CanvasElementItem>(
   const translateX = useSharedValue(initialX);
   const translateY = useSharedValue(initialY);
 
+  const adjustForSnapScale = (value: number) => {
+    return value - (value === 0 ? 0 : CANVAS_SNAP_SCALE_FACTOR);
+  };
+
   const dragGesture = Gesture.Pan()
     .onStart(() => {
       startX.value = translateX.value;
@@ -115,8 +119,8 @@ export const useDragElement = <T extends CanvasElementItem = CanvasElementItem>(
 
       hideSnapGuides();
 
-      const finalSnapX = finalX - (finalX === 0 ? 0 : CANVAS_SNAP_SCALE_FACTOR);
-      const finalSnapY = finalY - (finalY === 0 ? 0 : CANVAS_SNAP_SCALE_FACTOR);
+      const finalSnapX = adjustForSnapScale(finalX);
+      const finalSnapY = adjustForSnapScale(finalY);
 
       translateX.value = withSpring(finalSnapX, { damping: 20 });
       translateY.value = withSpring(finalSnapY, { damping: 20 });

--- a/src/hooks/useDragElement.ts
+++ b/src/hooks/useDragElement.ts
@@ -11,6 +11,7 @@ export interface DragElementOptions<T extends CanvasElementItem = CanvasElementI
   elementWidth: number;
   elementHeight: number;
   isElementSelected: boolean;
+  canvasScale?: number; // Optional scale factor for the canvas
   onSelectElement: (element: T | null) => void;
   onUpdate: (updates: Partial<T>) => void;
   updateSnapGuides: (x: number, y: number, bounds: SnapBounds) => void;
@@ -41,6 +42,7 @@ export interface DragElementOptions<T extends CanvasElementItem = CanvasElementI
  *   elementWidth: 80,
  *   elementHeight: 80,
  *   isElementSelected: true,
+ *   canvasScale: 1,
  *   onSelectElement: (element) => setSelectedElement(element),
  *   onUpdate: (updates) => handleElementUpdate(updates),
  *   updateSnapGuides: (x, y, bounds) => showSnapGuides(x, y, bounds),
@@ -67,6 +69,7 @@ export const useDragElement = <T extends CanvasElementItem = CanvasElementItem>(
     elementWidth,
     elementHeight,
     isElementSelected,
+    canvasScale = 1,
     onSelectElement,
     onUpdate,
     updateSnapGuides,
@@ -90,8 +93,8 @@ export const useDragElement = <T extends CanvasElementItem = CanvasElementItem>(
         onSelectElement(null);
       }
 
-      translateX.value = startX.value + e.translationX;
-      translateY.value = startY.value + e.translationY;
+      translateX.value = startX.value + e.translationX / canvasScale;
+      translateY.value = startY.value + e.translationY / canvasScale;
 
       updateSnapGuides(translateX.value, translateY.value, {
         canvasWidth,

--- a/src/hooks/useDragElement.ts
+++ b/src/hooks/useDragElement.ts
@@ -1,7 +1,9 @@
+import type { CanvasElementItem } from '@/types/editor';
 import { Gesture } from 'react-native-gesture-handler';
 import { useSharedValue, withSpring } from 'react-native-reanimated';
+import type { SnapBounds, SnapResult } from './useSnapGuide';
 
-export interface DragElementOptions {
+export interface DragElementOptions<T extends CanvasElementItem = CanvasElementItem> {
   initialX: number;
   initialY: number;
   canvasWidth: number;
@@ -9,10 +11,10 @@ export interface DragElementOptions {
   elementWidth: number;
   elementHeight: number;
   isElementSelected: boolean;
-  onSelectElement: (element: any) => void;
-  onUpdate: (updates: any) => void;
-  updateSnapGuides: (x: number, y: number, bounds: any) => void;
-  calculateSnapPosition: (x: number, y: number, bounds: any) => { finalX: number; finalY: number };
+  onSelectElement: (element: T | null) => void;
+  onUpdate: (updates: Partial<T>) => void;
+  updateSnapGuides: (x: number, y: number, bounds: SnapBounds) => void;
+  calculateSnapPosition: (x: number, y: number, bounds: SnapBounds) => SnapResult;
   hideSnapGuides: () => void;
 }
 
@@ -54,7 +56,9 @@ export interface DragElementOptions {
  * </Animated.View>
  * ```
  */
-export const useDragElement = (options: DragElementOptions) => {
+export const useDragElement = <T extends CanvasElementItem = CanvasElementItem>(
+  options: DragElementOptions<T>
+) => {
   const {
     initialX,
     initialY,
@@ -112,7 +116,7 @@ export const useDragElement = (options: DragElementOptions) => {
       onUpdate({
         x: snapResult.finalX,
         y: snapResult.finalY,
-      });
+      } as Partial<T>);
     })
     .runOnJS(true);
 

--- a/src/hooks/useDragElement.ts
+++ b/src/hooks/useDragElement.ts
@@ -94,8 +94,9 @@ export const useDragElement = <T extends CanvasElementItem = CanvasElementItem>(
         onSelectElement(null);
       }
 
-      translateX.value = startX.value + e.translationX / canvasScale;
-      translateY.value = startY.value + e.translationY / canvasScale;
+      const safeCanvasScale = canvasScale && canvasScale !== 0 ? canvasScale : 1;
+      translateX.value = startX.value + e.translationX / safeCanvasScale;
+      translateY.value = startY.value + e.translationY / safeCanvasScale;
 
       updateSnapGuides(translateX.value, translateY.value, {
         canvasWidth,

--- a/src/hooks/useDragElement.ts
+++ b/src/hooks/useDragElement.ts
@@ -94,7 +94,7 @@ export const useDragElement = <T extends CanvasElementItem = CanvasElementItem>(
         onSelectElement(null);
       }
 
-      const safeCanvasScale = canvasScale && canvasScale !== 0 ? canvasScale : 1;
+      const safeCanvasScale = canvasScale ?? 1;
       translateX.value = startX.value + e.translationX / safeCanvasScale;
       translateY.value = startY.value + e.translationY / safeCanvasScale;
 

--- a/src/hooks/usePinchGesture.ts
+++ b/src/hooks/usePinchGesture.ts
@@ -1,5 +1,5 @@
 import { clamp, screenHeight, screenWidth } from '@/utils';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { Gesture } from 'react-native-gesture-handler';
 import { useSharedValue } from 'react-native-reanimated';
 
@@ -50,6 +50,11 @@ export const usePinchGesture = (options: PinchGestureOptions = {}) => {
   const scale = useSharedValue(initialScale);
   const startScale = useSharedValue(initialScale);
 
+  useEffect(() => {
+    scale.value = initialScale;
+    startScale.value = initialScale;
+  }, [initialScale, scale, startScale]);
+
   const optimizedClamp = useCallback(clamp, []);
 
   const pinch = Gesture.Pinch()
@@ -67,16 +72,10 @@ export const usePinchGesture = (options: PinchGestureOptions = {}) => {
     })
     .runOnJS(true);
 
-  const resetScale = useCallback(() => {
-    scale.value = initialScale;
-    startScale.value = initialScale;
-  }, [initialScale]);
-
   return {
     pinch,
     scale,
     startScale,
-    resetScale,
   };
 };
 

--- a/src/hooks/usePinchGesture.ts
+++ b/src/hooks/usePinchGesture.ts
@@ -4,6 +4,7 @@ import { Gesture } from 'react-native-gesture-handler';
 import { useSharedValue } from 'react-native-reanimated';
 
 export interface PinchGestureOptions {
+  selectedId?: string;
   initialScale?: number;
   minScale?: number;
   maxScale?: number;
@@ -45,6 +46,7 @@ export const usePinchGesture = (options: PinchGestureOptions = {}) => {
     onStart,
     onUpdate,
     onEnd,
+    selectedId,
   } = options;
 
   const scale = useSharedValue(initialScale);
@@ -53,7 +55,7 @@ export const usePinchGesture = (options: PinchGestureOptions = {}) => {
   useEffect(() => {
     scale.value = initialScale;
     startScale.value = initialScale;
-  }, [initialScale, scale, startScale]);
+  }, [initialScale, scale, startScale, selectedId]);
 
   const optimizedClamp = useCallback(clamp, []);
 

--- a/src/hooks/usePinchGesture.ts
+++ b/src/hooks/usePinchGesture.ts
@@ -1,0 +1,83 @@
+import { clamp, screenHeight, screenWidth } from '@/utils';
+import { useCallback } from 'react';
+import { Gesture } from 'react-native-gesture-handler';
+import { useSharedValue } from 'react-native-reanimated';
+
+export interface PinchGestureOptions {
+  initialScale?: number;
+  minScale?: number;
+  maxScale?: number;
+  onStart?: () => void;
+  onUpdate?: (scale: number) => void;
+  onEnd?: (scale: number) => void;
+}
+
+/**
+ * Custom hook for handling pinch gestures with scale constraints
+ *
+ * This hook provides pinch gesture functionality with configurable min/max scale limits.
+ * It manages the scale state and provides smooth pinch-to-zoom functionality.
+ *
+ * @param options Configuration options for the pinch gesture
+ * @returns Object containing pinch gesture, scale values, and reset function
+ *
+ * @example
+ * ```typescript
+ * const { pinch, scale, resetScale } = usePinchGesture({
+ *   minScale: 0.5,
+ *   maxScale: 3,
+ *   onUpdate: (currentScale) => console.log('Scale:', currentScale)
+ * });
+ *
+ * // Use with Animated.View
+ * <GestureDetector gesture={pinch}>
+ *   <Animated.View style={[{ transform: [{ scale: scale }] }]}>
+ *     <YourContent />
+ *   </Animated.View>
+ * </GestureDetector>
+ * ```
+ */
+export const usePinchGesture = (options: PinchGestureOptions = {}) => {
+  const {
+    initialScale = 1,
+    minScale = 0.5,
+    maxScale = Math.min(screenWidth / 100, screenHeight / 100),
+    onStart,
+    onUpdate,
+    onEnd,
+  } = options;
+
+  const scale = useSharedValue(initialScale);
+  const startScale = useSharedValue(initialScale);
+
+  const optimizedClamp = useCallback(clamp, []);
+
+  const pinch = Gesture.Pinch()
+    .onStart(() => {
+      startScale.value = scale.value;
+      onStart?.();
+    })
+    .onUpdate(event => {
+      const newScale = optimizedClamp(startScale.value * event.scale, minScale, maxScale);
+      scale.value = newScale;
+      onUpdate?.(newScale);
+    })
+    .onEnd(() => {
+      onEnd?.(scale.value);
+    })
+    .runOnJS(true);
+
+  const resetScale = useCallback(() => {
+    scale.value = initialScale;
+    startScale.value = initialScale;
+  }, [initialScale]);
+
+  return {
+    pinch,
+    scale,
+    startScale,
+    resetScale,
+  };
+};
+
+export type UsePinchGestureReturn = ReturnType<typeof usePinchGesture>;

--- a/src/hooks/useResizeElement.ts
+++ b/src/hooks/useResizeElement.ts
@@ -4,6 +4,7 @@ import { Gesture } from 'react-native-gesture-handler';
 import { useSharedValue } from 'react-native-reanimated';
 
 export interface ResizeElementOptions {
+  elementId: string;
   initialWidth: number;
   initialHeight: number;
   minWidth?: number;
@@ -41,6 +42,7 @@ export interface ResizeElementOptions {
  */
 export const useResizeElement = (options: ResizeElementOptions) => {
   const {
+    elementId,
     initialWidth,
     initialHeight,
     minWidth = 10,
@@ -62,7 +64,7 @@ export const useResizeElement = (options: ResizeElementOptions) => {
   useEffect(() => {
     boxWidth.value = initialWidth;
     boxHeight.value = initialHeight;
-  }, [initialWidth, initialHeight, boxWidth, boxHeight]);
+  }, [elementId]);
 
   /**
    * Calculate new dimensions with constraints applied

--- a/src/hooks/useResizeElement.ts
+++ b/src/hooks/useResizeElement.ts
@@ -1,4 +1,5 @@
 import { clamp } from '@/utils';
+import { useEffect } from 'react';
 import { Gesture } from 'react-native-gesture-handler';
 import { useSharedValue } from 'react-native-reanimated';
 
@@ -42,8 +43,8 @@ export const useResizeElement = (options: ResizeElementOptions) => {
   const {
     initialWidth,
     initialHeight,
-    minWidth = 50,
-    minHeight = 25,
+    minWidth = 10,
+    minHeight = 10,
     maxWidth = Infinity,
     maxHeight = Infinity,
     maintainAspectRatio = false,
@@ -57,6 +58,11 @@ export const useResizeElement = (options: ResizeElementOptions) => {
   const startHeight = useSharedValue(initialHeight);
 
   const aspectRatio = initialWidth / initialHeight;
+
+  useEffect(() => {
+    boxWidth.value = initialWidth;
+    boxHeight.value = initialHeight;
+  }, [initialWidth, initialHeight, boxWidth, boxHeight]);
 
   /**
    * Calculate new dimensions with constraints applied

--- a/src/hooks/useTapElement.ts
+++ b/src/hooks/useTapElement.ts
@@ -1,9 +1,10 @@
+import type { CanvasElementItem } from '@/types/editor';
 import { Gesture } from 'react-native-gesture-handler';
 
-export interface TapElementOptions {
+export interface TapElementOptions<T extends CanvasElementItem = CanvasElementItem> {
   isElementSelected: boolean;
-  element: any;
-  onSelectElement: (element: any) => void;
+  element: T;
+  onSelectElement: (element: T | null) => void;
   onTapAction?: () => void;
   numberOfTaps?: number;
   maxDelayMs?: number;
@@ -29,7 +30,9 @@ export interface TapElementOptions {
  * </GestureDetector>
  * ```
  */
-export const useTapElement = (options: TapElementOptions) => {
+export const useTapElement = <T extends CanvasElementItem = CanvasElementItem>(
+  options: TapElementOptions<T>
+) => {
   const {
     isElementSelected,
     element,

--- a/src/screens/MemeEditorScreen/index.tsx
+++ b/src/screens/MemeEditorScreen/index.tsx
@@ -1,5 +1,5 @@
 import MemeEditor from '@/features/MemeEditor';
-import { SafeAreaView, View } from 'react-native';
+import { SafeAreaView } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { styles } from './style';
 
@@ -7,9 +7,7 @@ const MemeEditorScreen: React.FC = () => {
   return (
     <GestureHandlerRootView>
       <SafeAreaView style={styles.container}>
-        <View style={styles.playground}>
-          <MemeEditor />
-        </View>
+        <MemeEditor />
       </SafeAreaView>
     </GestureHandlerRootView>
   );

--- a/src/screens/MemeEditorScreen/style.ts
+++ b/src/screens/MemeEditorScreen/style.ts
@@ -3,17 +3,12 @@ import { StyleSheet } from 'react-native';
 
 export const styles = StyleSheet.create({
   container: {
-    backgroundColor: Colors.white,
     flex: 1,
+    position: 'relative',
   },
   header: {
     alignItems: 'center',
     padding: 20,
-  },
-  playground: {
-    backgroundColor: Colors.backgroundSecondary,
-    flex: 1,
-    position: 'relative',
   },
   subtitle: {
     color: Colors.gray,

--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -5,6 +5,7 @@ export interface CanvasElement {
   width: number;
   height: number;
   backgroundImage?: ImageSourcePropType;
+  scale?: number;
 }
 
 export interface BaseElement {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,6 +2,7 @@ import { AspectRatio } from '@/types/editor';
 import { Dimensions, Image, ImageSourcePropType } from 'react-native';
 
 export const { width: windowWidth, height: windowHeight } = Dimensions.get('window');
+export const { width: screenWidth, height: screenHeight } = Dimensions.get('screen');
 
 export interface CanvasDimensions {
   width: number;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,7 @@
 import { AspectRatio } from '@/types/editor';
 import { Dimensions, Image, ImageSourcePropType } from 'react-native';
 
-export const { width: screenWidth, height: screenHeight } = Dimensions.get('window');
+export const { width: windowWidth, height: windowHeight } = Dimensions.get('window');
 
 export interface CanvasDimensions {
   width: number;
@@ -29,8 +29,8 @@ export const calculateCanvasDimensions = (
     Image.getSize(
       Image.resolveAssetSource(imageSource).uri,
       (imageWidth, imageHeight) => {
-        const maxAvailableWidth = screenWidth - horizontalMargin;
-        const maxAvailableHeight = screenHeight - verticalMargin;
+        const maxAvailableWidth = windowWidth - horizontalMargin;
+        const maxAvailableHeight = windowHeight - verticalMargin;
 
         const scaleWidth = maxAvailableWidth / imageWidth;
         const scaleHeight = maxAvailableHeight / imageHeight;
@@ -42,8 +42,8 @@ export const calculateCanvasDimensions = (
         resolve({ width: canvasWidth, height: canvasHeight });
       },
       () => {
-        const maxAvailableWidth = screenWidth - horizontalMargin;
-        const maxAvailableHeight = screenHeight - verticalMargin;
+        const maxAvailableWidth = windowWidth - horizontalMargin;
+        const maxAvailableHeight = windowHeight - verticalMargin;
         const squareSize = Math.min(maxAvailableWidth, maxAvailableHeight);
 
         resolve({
@@ -72,8 +72,8 @@ export const calculateCanvasDimensionsForAspectRatio = (
 ): CanvasDimensions => {
   const { horizontalMargin = 64, verticalMargin = 200 } = options;
 
-  const maxAvailableWidth = screenWidth - horizontalMargin;
-  const maxAvailableHeight = screenHeight - verticalMargin;
+  const maxAvailableWidth = windowWidth - horizontalMargin;
+  const maxAvailableHeight = windowHeight - verticalMargin;
 
   let width: number;
   let height: number;


### PR DESCRIPTION
> **_Note:_** 
> I usually separate each change into its own Pull Request. However, for testing purposes, I combined them into one.

# Changelog
- Improve the accuracy of the drag of text and images when the canvas is zoom
- Removes the maximum limit of element movement when the element is dragged
- Reset scale and canvas coordinates when deleting projects or selecting new templates
- Fix zIndex Element Action located under the Snap Guide
- Improve the accuracy of the Snap Guide X and Y coordinates
- Improve the coordinates of the elements attached to the Snap X and Y lines
- [Enhance type safety in drag and tap element options](https://github.com/thoriqdharmawan/meme-generator/pull/1/commits/a7e7b386b4c77d7aed634d717133390e52c8a7e2)
- Improve elements that require a 'screen' rather than a 'window' size

# Demo

<details>
<summary>Improve the accuracy of the drag of text and images when the canvas is zoom</summary>

### Before

https://github.com/user-attachments/assets/2c8cbea8-4f98-4ed2-9cf2-b472ba01a9a0

### After

https://github.com/user-attachments/assets/e61e3177-8fb0-44b5-aefa-0a19556c4242

</details>

<details>
<summary>Removes the maximum limit of element movement when the element is dragged</summary>

### Before

https://github.com/user-attachments/assets/2ee2b252-3c98-466f-a39c-312be5353fe2

### After

https://github.com/user-attachments/assets/2e5574be-df2b-4d3f-8be3-54a00028602a

</details>

<details>
<summary>Reset scale and canvas coordinates when deleting projects or selecting new templates</summary>

### Before

https://github.com/user-attachments/assets/19776a32-54d6-4ca9-80e0-645aaa281c96

### After

https://github.com/user-attachments/assets/d54ef77f-30c0-4259-b3f0-cc3121857da7

</details>

<details>
<summary>Fix zIndex Element Action located under the Snap Guide</summary>

### Before

https://github.com/user-attachments/assets/8d01afa1-9dbb-4b29-b27d-7b0ece82fc8b

### After

https://github.com/user-attachments/assets/e700096f-f107-407d-becc-061a1b98332a

</details>

<details>
<summary>Improve the accuracy of the Snap Guide X and Y coordinates</summary>

### Before

https://github.com/user-attachments/assets/a5c8cb6f-dc48-429c-ac57-48f00fe87c39

### After

https://github.com/user-attachments/assets/0c645b03-08d2-4772-976b-793265a515f4

</details>

<details>
<summary>Improve the coordinates of the elements attached to the Snap X and Y lines</summary>

### Before

https://github.com/user-attachments/assets/11ed84a1-c8a9-4e46-9f4b-379ca3ce16e4

### After

https://github.com/user-attachments/assets/0bb3dafb-a902-4587-b8c0-29369df01abe

</details>
